### PR TITLE
Base module unit tests fix

### DIFF
--- a/base/src/test/java/de/n26/n26androidsamples/base/common/rx/UnwrapOptionTransformerTest.java
+++ b/base/src/test/java/de/n26/n26androidsamples/base/common/rx/UnwrapOptionTransformerTest.java
@@ -4,8 +4,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import de.n26.n26androidsamples.base.BaseTest;
-import io.reactivex.Flowable;
-import io.reactivex.subscribers.TestSubscriber;
+import io.reactivex.Observable;
+import io.reactivex.observers.TestObserver;
 import polanski.option.Option;
 
 public class UnwrapOptionTransformerTest extends BaseTest {
@@ -19,9 +19,9 @@ public class UnwrapOptionTransformerTest extends BaseTest {
 
     @Test
     public void transformerFiltersOutNone() {
-        Flowable<Option<Object>> source = Flowable.just(Option.none());
+        Observable<Option<Object>> source = Observable.just(Option.none());
 
-        TestSubscriber<Object> ts = new TestSubscriber<>();
+        TestObserver<Object> ts = new TestObserver<>();
         transformer.apply(source).subscribe(ts);
 
         ts.assertNoValues();
@@ -30,11 +30,10 @@ public class UnwrapOptionTransformerTest extends BaseTest {
     @Test
     public void transformerUnwrapsSome() {
         Object object = new Object();
-        Flowable<Option<Object>> source = Flowable.just(Option.ofObj(object));
+        Observable<Option<Object>> source = Observable.just(Option.ofObj(object));
 
-        TestSubscriber<Object> ts = new TestSubscriber<>();
+        TestObserver<Object> ts = new TestObserver<>();
         transformer.apply(source).subscribe(ts);
-
         ts.assertValue(object);
     }
 }

--- a/base/src/test/java/de/n26/n26androidsamples/base/data/store/MemoryReactiveStoreTest.java
+++ b/base/src/test/java/de/n26/n26androidsamples/base/data/store/MemoryReactiveStoreTest.java
@@ -12,6 +12,8 @@ import java.util.List;
 import de.n26.n26androidsamples.base.BaseTest;
 import de.n26.n26androidsamples.base.data.cache.Cache;
 import io.reactivex.Maybe;
+import io.reactivex.observers.TestObserver;
+import polanski.option.Option;
 
 import static polanski.option.Option.none;
 import static polanski.option.Option.ofObj;
@@ -46,43 +48,53 @@ public class MemoryReactiveStoreTest extends BaseTest {
         reactiveStore.getSingular("ID1").test().assertValue(ofObj(model));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void streamsEmitWhenSingleObjectIsStored() {
         List<TestObject> list = createTestObjectList();
         TestObject model = new TestObject("ID1");
-        new ArrangeBuilder().withCachedObjectList(list)
-                            .withCachedObject(model);
+        new ArrangeBuilder().withEmptyCache();
+        TestObserver<Option<TestObject>> singleTestObserver = reactiveStore.getSingular("ID1").test();
+        TestObserver<Option<List<TestObject>>> listTestObserver = reactiveStore.getAll().test();
+        new ArrangeBuilder().withCachedObjectList(list);
 
         reactiveStore.storeSingular(model);
 
-        reactiveStore.getSingular("ID1").test().assertValue(ofObj(model));
-        reactiveStore.getAll().test().assertValue(ofObj(list));
+        singleTestObserver.assertValues(none(), ofObj(model));
+        listTestObserver.assertValues(none(), ofObj(list));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void streamsEmitWhenObjectListIsStored() {
         List<TestObject> list = createTestObjectList();
         TestObject model = new TestObject("ID1");
+        new ArrangeBuilder().withEmptyCache();
+        TestObserver<Option<TestObject>> singleTestObserver = reactiveStore.getSingular("ID1").test();
+        TestObserver<Option<List<TestObject>>> listTestObserver = reactiveStore.getAll().test();
         new ArrangeBuilder().withCachedObjectList(list)
                             .withCachedObject(model);
 
         reactiveStore.storeAll(list);
 
-        reactiveStore.getSingular("ID1").test().assertValue(ofObj(model));
-        reactiveStore.getAll().test().assertValue(ofObj(list));
+        singleTestObserver.assertValues(none(), ofObj(model));
+        listTestObserver.assertValues(none(), ofObj(list));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void streamsEmitWhenObjectListIsReplaced() {
         List<TestObject> list = createTestObjectList();
         TestObject model = new TestObject("ID1");
-        new ArrangeBuilder().withCachedObjectList(list)
-                            .withCachedObject(model);
+        new ArrangeBuilder().withEmptyCache();
+        TestObserver<Option<TestObject>> singleTestObserver = reactiveStore.getSingular("ID1").test();
+        TestObserver<Option<List<TestObject>>> listTestObserver = reactiveStore.getAll().test();
+        new ArrangeBuilder().withCachedObject(model);
 
         reactiveStore.replaceAll(list);
 
-        reactiveStore.getSingular("ID1").test().assertValue(ofObj(model));
-        reactiveStore.getAll().test().assertValue(ofObj(list));
+        singleTestObserver.assertValues(none(), ofObj(model));
+        listTestObserver.assertValues(none(), ofObj(list));
     }
 
     @Test

--- a/base/src/test/java/de/n26/n26androidsamples/base/data/store/MemoryReactiveStoreTest.java
+++ b/base/src/test/java/de/n26/n26androidsamples/base/data/store/MemoryReactiveStoreTest.java
@@ -48,53 +48,71 @@ public class MemoryReactiveStoreTest extends BaseTest {
         reactiveStore.getSingular("ID1").test().assertValue(ofObj(model));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
-    public void streamsEmitWhenSingleObjectIsStored() {
-        List<TestObject> list = createTestObjectList();
+    public void singularStreamEmitsWhenSingleObjectIsStored() {
         TestObject model = new TestObject("ID1");
         new ArrangeBuilder().withEmptyCache();
-        TestObserver<Option<TestObject>> singleTestObserver = reactiveStore.getSingular("ID1").test();
-        TestObserver<Option<List<TestObject>>> listTestObserver = reactiveStore.getAll().test();
-        new ArrangeBuilder().withCachedObjectList(list);
 
+        TestObserver<Option<TestObject>> to = reactiveStore.getSingular("ID1").test();
         reactiveStore.storeSingular(model);
 
-        singleTestObserver.assertValues(none(), ofObj(model));
-        listTestObserver.assertValues(none(), ofObj(list));
+        to.assertValueAt(1, testObjectOption -> testObjectOption.equals(ofObj(model)));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
-    public void streamsEmitWhenObjectListIsStored() {
+    public void allStreamEmitsWhenSingleObjectIsStored() {
         List<TestObject> list = createTestObjectList();
-        TestObject model = new TestObject("ID1");
-        new ArrangeBuilder().withEmptyCache();
-        TestObserver<Option<TestObject>> singleTestObserver = reactiveStore.getSingular("ID1").test();
-        TestObserver<Option<List<TestObject>>> listTestObserver = reactiveStore.getAll().test();
-        new ArrangeBuilder().withCachedObjectList(list)
-                            .withCachedObject(model);
+        new ArrangeBuilder().withCachedObjectList(list);
 
-        reactiveStore.storeAll(list);
+        TestObserver<Option<List<TestObject>>> to = reactiveStore.getAll().test();
+        reactiveStore.storeSingular(new TestObject(""));
 
-        singleTestObserver.assertValues(none(), ofObj(model));
-        listTestObserver.assertValues(none(), ofObj(list));
+        Mockito.verify(cache, Mockito.times(2)).getAll();
+        to.assertValueAt(1, listOption -> listOption.equals(ofObj(list)));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
-    public void streamsEmitWhenObjectListIsReplaced() {
-        List<TestObject> list = createTestObjectList();
+    public void singularStreamEmitsWhenObjectListIsStored() {
         TestObject model = new TestObject("ID1");
-        new ArrangeBuilder().withEmptyCache();
-        TestObserver<Option<TestObject>> singleTestObserver = reactiveStore.getSingular("ID1").test();
-        TestObserver<Option<List<TestObject>>> listTestObserver = reactiveStore.getAll().test();
         new ArrangeBuilder().withCachedObject(model);
 
+        TestObserver<Option<TestObject>> to = reactiveStore.getSingular("ID1").test();
+        reactiveStore.storeAll(createTestObjectList());
+
+        to.assertValueAt(1, testObjectOption -> testObjectOption.equals(ofObj(model)));
+    }
+
+    @Test
+    public void allStreamEmitsWhenObjectListIsStored() {
+        List<TestObject> list = createTestObjectList();
+        new ArrangeBuilder().withCachedObjectList(list);
+
+        TestObserver<Option<List<TestObject>>> to = reactiveStore.getAll().test();
+        reactiveStore.storeAll(list);
+
+        to.assertValueAt(1, listOption -> listOption.equals(ofObj(list)));
+    }
+
+    @Test
+    public void singularStreamEmitsWhenObjectListIsReplaced() {
+        TestObject model = new TestObject("ID1");
+        new ArrangeBuilder().withCachedObject(model);
+
+        TestObserver<Option<TestObject>> to = reactiveStore.getSingular("ID1").test();
+        reactiveStore.replaceAll(createTestObjectList());
+
+        to.assertValueAt(1, testObjectOption -> testObjectOption.equals(ofObj(model)));
+    }
+
+    @Test
+    public void allStreamEmitsWhenObjectListIsReplaced() {
+        List<TestObject> list = createTestObjectList();
+        new ArrangeBuilder().withCachedObjectList(list);
+
+        TestObserver<Option<List<TestObject>>> to = reactiveStore.getAll().test();
         reactiveStore.replaceAll(list);
 
-        singleTestObserver.assertValues(none(), ofObj(model));
-        listTestObserver.assertValues(none(), ofObj(list));
+        to.assertValueAt(1, listOption -> listOption.equals(ofObj(list)));
     }
 
     @Test


### PR DESCRIPTION
**UnwrapOptionTransformerTest class**
Is not compilable because `transformer.apply` was passed a Flowable instance instead of Observable, so I changed the Flowable instance to an Observable.

**MemoryReactiveStoreTest class**

- `streamsEmitWhenSingleObjectIsStored()` method:
The statement `reactiveStore.storeSingular(model)` does not affect the test result, I modified the test so that statement would affect the result.

- `streamsEmitWhenObjectListIsStored()` method:
The statement `reactiveStore.storeAll(list)` does not affect the test result, I modified the test so that statement would affect the result.

- `streamsEmitWhenObjectListIsReplaced()` method:
The statement `reactiveStore.replaceAll(list)` does not affect the test result, I modified the test so that statement would affect the result.